### PR TITLE
bugfix

### DIFF
--- a/src/19 component.js
+++ b/src/19 component.js
@@ -28,7 +28,12 @@ avalon.component = function (name, opts) {
             i--;
 
             (function (host, hooks, elem, widget) {
-
+                //如果elem已从Document里移除,直接返回
+                //issuse : https://github.com/RubyLouvre/avalon2/issues/40
+                if (!avalon.contains(DOC, elem)) {
+                    return
+                }
+                
                 var dependencies = 1
                 var library = host.library
                 var global = avalon.libraries[library] || componentHooks


### PR DESCRIPTION
https://github.com/RubyLouvre/avalon2/issues/40
avalon.component异步执行的时候dom可能已从dom树移除了